### PR TITLE
Add service tag filter support

### DIFF
--- a/consul.js
+++ b/consul.js
@@ -13,7 +13,7 @@
 
   var basePath = '/v1/catalog/service/'
   var requiredParams = ['service', 'servers']
-  var consulParams = ['service', 'datacenter', 'protocol']
+  var consulParams = ['service', 'datacenter', 'protocol', 'tag']
 
   exports.resilientConsul = function (params) {
     var type = 'discovery'
@@ -50,6 +50,10 @@
 
         if (params.datacenter) {
           options.params.dc = params.datacenter
+        }
+
+        if (params.tag) {
+          options.params.tag = params.tag
         }
 
         next()

--- a/test/consul.js
+++ b/test/consul.js
@@ -28,12 +28,13 @@ suite('Consul', function () {
   })
 
   test('out middleware', function (done) {
-    var md = consul({ service: 'test', servers: ['http://test'], datacenter: 'aws' }) 
+    var md = consul({ service: 'test', servers: ['http://test'], datacenter: 'aws', tag: 'foo' }) 
     var options = {}
     
     md(optionsStub)['out'](options, function (err) {
       expect(err).to.be.undefined
       expect(options.params.dc).to.be.equal('aws')
+      expect(options.params.tag).to.be.equal('foo')
       done()
     })
   })
@@ -47,7 +48,8 @@ suite('Consul', function () {
           "Address": "10.1.10.12",
           "ServiceName": "web",
           "ServiceAddress": "",
-          "ServicePort": 8000
+          "ServicePort": 8000,
+          "ServiceTags": ["foo"]
         }
       ]
     }


### PR DESCRIPTION
A small change to add service filtering by tag, supported by consul v1 api.
