### PR TITLE
Add option for custom server filtering/mapping logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,13 @@ client.use(consul({
   servers: [
     'http://demo.consul.io',
     'http://demo.consul.io'
-  ]
+  ],
+  // Use a custom mapping function (optional)
+  mapServers: function (list) {
+    // here you can filter/map the services retrieved from Consul
+    // to a list of addresses according to custom logic:
+    return list.map(function (svc) { return svc.ServiceAddress + '/v1' })
+  }
 }))
 
 // Test request
@@ -96,6 +102,7 @@ To do that you can define additional response HTTP headers in the Consul config 
 - **datacenter** `string` - Custom datacenter to use. If not defined the default one will be used 
 - **tag** `string` - Use a specific tag for the service
 - **protocol** `string` - Transport URI protocol. Default to `http`
+- **mapServers** `function` - Custom function for creating the list of service addresses based on the Consul response
 
 Additionally you can pass any of the supported Resilient 
 [discovery options](https://github.com/resilient-http/resilient.js#discovery) via this middleware

--- a/consul.js
+++ b/consul.js
@@ -13,7 +13,7 @@
 
   var basePath = '/v1/catalog/service/'
   var requiredParams = ['service', 'servers']
-  var consulParams = ['service', 'datacenter', 'protocol', 'tag']
+  var consulParams = ['service', 'datacenter', 'protocol', 'tag', 'mapServers']
 
   exports.resilientConsul = function (params) {
     params = params || {}
@@ -25,6 +25,7 @@
     })
 
     params.basePath = basePath + params.service
+    params.mapServers = params.mapServers || mapServers;
 
     if (params.discoveryService) {
       params.refreshPath = basePath + params.discoveryService
@@ -38,7 +39,7 @@
         if (err) return next()
         
         if (Array.isArray(res.data)) {
-          res.data = mapServers(res.data)
+          res.data = params.mapServers(res.data)
         }
 
         next()


### PR DESCRIPTION
#### Motivation

We use tags in Consul to attach metadata to service instances, e.g. version information, environments or proxy addresses to reach the service from outside the company network. A simple tag filter is not sufficient to express our needs when retrieving service information from the discovery.
#### Changes in this pull request

We introduced another option called `mapServers` which -- if set -- will be used to transform the list of services retrieved from the discovery service to a list of service addresses based on custom logic. If the option is not set, the default implementation will be used, making this change downwards compatible.
