### PR TITLE
Add option to use Consul's health check endpoint instead of the catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,13 @@ client.use(consul({
     'http://demo.consul.io',
     'http://demo.consul.io'
   ],
+  // Use Consul's health check endpoint instead of the catalog
+  // to retrieve only services with passing health checks (optional)
+  onlyHealthy: false,
   // Use a custom mapping function (optional)
   mapServers: function (list) {
     // here you can filter/map the services retrieved from Consul
-    // to a list of addresses according to custom logic:
+    // to a list of addresses according to custom logic (optional)
     return list.map(function (svc) { return svc.ServiceAddress + '/v1' })
   }
 }))
@@ -101,6 +104,7 @@ To do that you can define additional response HTTP headers in the Consul config 
 - **discoveryService** `string` - Consul discovery service for auto balancing
 - **datacenter** `string` - Custom datacenter to use. If not defined the default one will be used 
 - **tag** `string` - Use a specific tag for the service
+- **onlyHealthy** `boolean` - Use Consul's health check endpoint instead of the catalog to retrieve only services with passing health checks. Default to `false`
 - **protocol** `string` - Transport URI protocol. Default to `http`
 - **mapServers** `function` - Custom function for creating the list of service addresses based on the Consul response
 

--- a/test/consul.js
+++ b/test/consul.js
@@ -35,6 +35,20 @@ suite('Consul', function () {
       expect(err).to.be.undefined
       expect(options.params.dc).to.be.equal('aws')
       expect(options.params.tag).to.be.equal('foo')
+      expect(options.params.passing).to.be.undefined
+      done()
+    })
+  })
+
+  test('out middleware using health', function (done) {
+    var md = consul({ service: 'test', servers: ['http://test'], datacenter: 'aws', tag: 'foo', onlyHealthy: true }) 
+    var options = {}
+    
+    md(optionsStub)['out'](options, function (err) {
+      expect(err).to.be.undefined
+      expect(options.params.dc).to.be.equal('aws')
+      expect(options.params.tag).to.be.equal('foo')
+      expect(options.params.passing).to.be.true
       done()
     })
   })
@@ -50,6 +64,56 @@ suite('Consul', function () {
           "ServiceAddress": "",
           "ServicePort": 8000,
           "ServiceTags": ["foo"]
+        }
+      ]
+    }
+    
+    md(optionsStub)['in'](null, res, function (err) {
+      expect(err).to.be.undefined
+      expect(res.data).to.be.an('array')
+      expect(res.data[0]).to.be.equal('http://10.1.10.12:8000')
+      done()
+    })
+  })
+
+  test('in middleware using health', function (done) {
+    var md = consul({ service: 'test', servers: ['http://test'], datacenter: 'aws', onlyHealthy: true }) 
+    var res = { 
+      data: [
+        {
+          "Node": {
+            "Node": "test",
+            "Address": "10.1.10.12"
+          },
+          "Service": {
+            "ID": "test:web:8000",
+            "Service": "web",
+            "Tags": null,
+            "Address": "10.1.10.12",
+            "Port": 8000
+          },
+          "Checks": [
+            {
+              "Node": "test",
+              "CheckID": "service:test:web:8000",
+              "Name": "Service 'web' check",
+              "Status": "passing",
+              "Notes": "",
+              "Output": "HTTP GET http://10.1.10.12:8000/healthcheck: 200 OK Output: {\"message\":\"ok\"}",
+              "ServiceID": "test:web:8000",
+              "ServiceName": "web"
+            },
+            {
+              "Node": "test",
+              "CheckID": "serfHealth",
+              "Name": "Serf Health Status",
+              "Status": "passing",
+              "Notes": "",
+              "Output": "Agent alive and reachable",
+              "ServiceID": "",
+              "ServiceName": ""
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
To avoid extra filtering logic on the client, the `onlyHealthy` option is introduced. When set to `true`, the middleware will retrieve services from Consul's [health endpoint](https://consul.io/docs/agent/http/health.html#health_service) using the `passing` flag.
